### PR TITLE
thinsnap: remove -K for snapshot creation

### DIFF
--- a/lvmd/command/lvm.go
+++ b/lvmd/command/lvm.go
@@ -659,7 +659,7 @@ func (l *LogicalVolume) Activate(access string) error {
 	var lvchangeArgs []string
 	switch access {
 	case "ro":
-		lvchangeArgs = []string{"-p", "r", "-K", l.path}
+		lvchangeArgs = []string{"-p", "r", l.path}
 	case "rw":
 		lvchangeArgs = []string{"-a", "y", "-K", l.path}
 	default:


### PR DESCRIPTION
adding skip was causing activation failure for
snapshots. This commit removes it.

Signed-off-by: Yug Gupta <yuggupta27@gmail.com>