### PR TITLE
mount: remove new UUID generation

### DIFF
--- a/driver/node.go
+++ b/driver/node.go
@@ -170,9 +170,6 @@ func (s *nodeService) nodePublishFilesystemVolume(req *csi.NodePublishVolumeRequ
 	// avoid duplicate UUIDs
 	if mountOption.FsType == "xfs" {
 		mountOptions = append(mountOptions, "nouuid")
-		s.mounter.Exec.Command("xfs_admin", "-U", "generate", device)
-	} else if mountOption.FsType == "ext4" {
-		s.mounter.Exec.Command("tune2fs", "-U", "random", device)
 	}
 
 	mounted, err := filesystem.IsMounted(device, req.GetTargetPath())


### PR DESCRIPTION
On generating a new UUID(using xfs_admin here), the mount_linux
re-formats the file system; due to which all
the data in the PVC-Clone and PVC-Restore
volume is removed.

To address this issue, we use the `nouuid` mountoption.
Adding 'nouuid' mount option to all XFS mount so that
we will be able to mount a volume and its restored snapshot on
the same node. Without the option, such a mount fails
, because XFS detects that two different volumes with the same
filesystem UUID are being mounted

On the other hand, ext4, by nature, has the nouuid enabled due to which
we dont need to generate a new UUID there too.

Signed-off-by: Yug Gupta <yuggupta27@gmail.com>
(cherry picked from commit 1edcd6195e3b015e88aeade1a2586e82261865a3)
Signed-off-by: N Balachandran <nibalach@redhat.com>