### PR TITLE
Bug 2142781: fix: consider spare-gb in free space calculations

### DIFF
--- a/e2e/node_test.go
+++ b/e2e/node_test.go
@@ -105,10 +105,23 @@ func testNode() {
 				"--nosuffix",
 				vgName,
 			)
+
 			Expect(err).ShouldNot(HaveOccurred(), "stdout=%s, stderr=%s", targetBytes, stderr)
+
+			free, err := strconv.Atoi(strings.TrimSpace(string(targetBytes)))
+			Expect(err).ShouldNot(HaveOccurred())
+
+			// spare-gb is set to 1 in the manifests
+			spare := 1 << 30
+			if free < spare {
+				free = 0
+			} else {
+				free -= spare
+			}
+
 			val, ok := node.Annotations[topolvm.GetCapacityKeyPrefix()+"ssd"]
 			Expect(ok).To(Equal(true), "capacity is not annotated: "+node.Name)
-			Expect(val).To(Equal(strings.TrimSpace(string(targetBytes))), "unexpected capacity: "+node.Name)
+			Expect(val).To(Equal(strconv.Itoa(free)), "unexpected capacity: "+node.Name)
 		}
 	})
 

--- a/example/Makefile
+++ b/example/Makefile
@@ -85,7 +85,7 @@ $(TMPDIR)/scheduler/scheduler-config.yaml: ../deploy/scheduler-config/$(SCHEDULE
 
 $(TMPDIR)/lvmd/lvmd.yaml: ../deploy/lvmd-config/lvmd.yaml
 	mkdir -p $(TMPDIR)/lvmd
-	sed -e 's=/run/topolvm/lvmd.sock=$(TMPDIR)/lvmd/lvmd.sock=' $< > $@
+	sed -e 's=/run/topolvm/lvmd.sock=$(TMPDIR)/lvmd/lvmd.sock=; s=spare-gb: 10=spare-gb: 1=' $< > $@
 
 .PHONY: launch-kind
 launch-kind: $(TMPDIR)/scheduler/scheduler-config.yaml

--- a/lvmd/vgservice.go
+++ b/lvmd/vgservice.go
@@ -193,6 +193,14 @@ func (s *vgService) send(server proto.VGService_WatchServer) error {
 		if err == ErrNotFound {
 			continue
 		}
+
+		spare := dc.GetSpare()
+		if vgFree < spare {
+			vgFree = 0
+		} else {
+			vgFree -= spare
+		}
+
 		if dc.Default {
 			res.FreeBytes = vgFree
 		}


### PR DESCRIPTION
VGService.send should consider the spare-gb when calculating the free space in a VG.

Signed-off-by: N Balachandran <nibalach@redhat.com>